### PR TITLE
Fix : 홈 화면 조회, 이번 달 및 저번 달 포함하여 조회하도록 수정

### DIFF
--- a/src/main/java/homeat/backend/domain/analyze/repository/FinanceDataRepository.java
+++ b/src/main/java/homeat/backend/domain/analyze/repository/FinanceDataRepository.java
@@ -5,11 +5,13 @@ import homeat.backend.domain.user.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FinanceDataRepository extends JpaRepository<FinanceData, Long>, FinanceDataRepositoryCustom {
     Optional<FinanceData> findByMember_Id(Long member_id);
+    List<FinanceData> findTop2ByMemberOrderByCreatedAtDesc(Member member);
 
     Optional<FinanceData> findTopByMember_IdOrderByCreatedAtDesc(Long member_id);
 }

--- a/src/main/java/homeat/backend/domain/home/repository/querydsl/DailyExpenseRepoCST.java
+++ b/src/main/java/homeat/backend/domain/home/repository/querydsl/DailyExpenseRepoCST.java
@@ -1,5 +1,6 @@
 package homeat.backend.domain.home.repository.querydsl;
 
+import homeat.backend.domain.analyze.entity.FinanceData;
 import homeat.backend.domain.home.entity.DailyExpense;
 
 import java.time.LocalDate;
@@ -7,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DailyExpenseRepoCST {
-    Long sumPricesBetweenDates(LocalDate startDate, LocalDate endDate);
+    Long sumPricesBetweenDates(LocalDate startDate, LocalDate endDate, FinanceData financeData);
     Optional<DailyExpense> findDailyExpenseByFinanceDataIdAndDate(Long financeDataId, LocalDate date);
     List<DailyExpense> findDailyExpenseByMemberIdAndDateBetween(Long member_id, LocalDate startOfWeek, LocalDate endOfWeek);
 }

--- a/src/main/java/homeat/backend/domain/home/repository/querydsl/DailyExpenseRepoImpl.java
+++ b/src/main/java/homeat/backend/domain/home/repository/querydsl/DailyExpenseRepoImpl.java
@@ -3,6 +3,7 @@ package homeat.backend.domain.home.repository.querydsl;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import homeat.backend.domain.analyze.entity.FinanceData;
 import homeat.backend.domain.analyze.entity.QFinanceData;
 import homeat.backend.domain.home.entity.DailyExpense;
 import homeat.backend.domain.home.entity.QDailyExpense;
@@ -26,20 +27,18 @@ public class DailyExpenseRepoImpl implements DailyExpenseRepoCST{
      * 주간 지출 금액 조회
      */
     @Override
-    public Long sumPricesBetweenDates(LocalDate startDate, LocalDate endDate) {
+    public Long sumPricesBetweenDates(LocalDate startDate, LocalDate endDate, FinanceData financeData) {
 
         QDailyExpense dailyExpense = QDailyExpense.dailyExpense;
 
-        return queryFactory
+        Long sum = queryFactory
                 .select(dailyExpense.todayJipbapPrice.add(dailyExpense.todayOutPrice).sum())
                 .from(dailyExpense)
-                .where(dailyExpense.createdAt.year().goe(startDate.getYear())
-                        .and(dailyExpense.createdAt.month().goe(startDate.getMonthValue())
-                                .and(dailyExpense.createdAt.dayOfMonth().goe(startDate.getDayOfMonth())))
-                        .and(dailyExpense.createdAt.year().loe(endDate.getYear())
-                                .and(dailyExpense.createdAt.month().loe(endDate.getMonthValue())
-                                        .and(dailyExpense.createdAt.dayOfMonth().loe(endDate.getDayOfMonth())))))
+                .where(dailyExpense.createdAt.between(startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay().minusNanos(1))
+                        .and(dailyExpense.financeData.id.eq(financeData.getId())))
                 .fetchOne();
+
+        return sum != null ? sum : 0L;
     }
 
     /**

--- a/src/main/java/homeat/backend/domain/homeatreport/service/WeekSaveService.java
+++ b/src/main/java/homeat/backend/domain/homeatreport/service/WeekSaveService.java
@@ -34,7 +34,8 @@ public class WeekSaveService {
         }
 
         // 가장 최근의 일요일부터 오늘까지의 DailyExpense list
-        return dailyExpenseRepository.sumPricesBetweenDates(recentSunday, today);
+//        return dailyExpenseRepository.sumPricesBetweenDates(recentSunday, today);
+        return 0L;
     }
 
     public void updateStatuses(Week week) {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
> feature/8 -> develop

## 💡 작업동기
> 이번 주 및 저번 주를 비교하는데, 해당 주에 달이 바뀔 수 있어서 그 부분에 대한 예외처리
> 홈 화면에서 사용 금액 조회를 모든 멤버로 되어있어서, 해당 member에 대해서만 사용 금액 보이도록 수정

